### PR TITLE
`Material.get_diffusion_coefficient` doesn't require list of species

### DIFF
--- a/festim/hydrogen_transport_problem.py
+++ b/festim/hydrogen_transport_problem.py
@@ -265,7 +265,7 @@ class HydrogenTransportProblem:
 
             for vol in self.volume_subdomains:
                 D = vol.material.get_diffusion_coefficient(
-                    self.mesh.mesh, self.temperature, spe, self.species
+                    self.mesh.mesh, self.temperature, spe
                 )
 
                 self.formulation += dot(D * grad(u), grad(v)) * self.dx(vol.id)
@@ -307,7 +307,7 @@ class HydrogenTransportProblem:
 
         n = self.mesh.n
         D = self.subdomains[0].material.get_diffusion_coefficient(
-            self.mesh.mesh, self.temperature, self.species[0], self.species
+            self.mesh.mesh, self.temperature, self.species[0]
         )
         cm = self.species[0].solution
         progress = tqdm.autonotebook.tqdm(

--- a/test/test_material.py
+++ b/test/test_material.py
@@ -99,7 +99,6 @@ def test_D_0_type_rasies_error():
     """Test that a value error is rasied in the get_diffusion_coefficient
     function"""
     A = F.Species("A")
-    spe_list = [A]
     my_mat = F.Material(D_0=[1, 1], E_D=0.1)
 
     with pytest.raises(ValueError, match="D_0 and E_D must be either floats or dicts"):

--- a/test/test_material.py
+++ b/test/test_material.py
@@ -10,9 +10,7 @@ def test_define_diffusion_coefficient():
     T, D_0, E_D = 10, 1.2, 0.5
     dum_spe = F.Species("dummy")
     my_mat = F.Material(D_0=D_0, E_D=E_D)
-    D = my_mat.get_diffusion_coefficient(
-        test_mesh.mesh, T, species=dum_spe, model_species=[dum_spe]
-    )
+    D = my_mat.get_diffusion_coefficient(test_mesh.mesh, T, species=dum_spe)
 
     D_analytical = D_0 * np.exp(-E_D / F.k_B / T)
 
@@ -26,15 +24,10 @@ def test_multispecies_dict_strings():
     D_0_A, D_0_B = 1, 2
     E_D_A, E_D_B = 0.1, 0.2
     A, B = F.Species("A"), F.Species("B")
-    spe_list = [A, B]
 
     my_mat = F.Material(D_0={"A": D_0_A, "B": D_0_B}, E_D={"A": E_D_A, "B": E_D_B})
-    D_A = my_mat.get_diffusion_coefficient(
-        test_mesh.mesh, T, species=A, model_species=spe_list
-    )
-    D_B = my_mat.get_diffusion_coefficient(
-        test_mesh.mesh, T, species=B, model_species=spe_list
-    )
+    D_A = my_mat.get_diffusion_coefficient(test_mesh.mesh, T, species=A)
+    D_B = my_mat.get_diffusion_coefficient(test_mesh.mesh, T, species=B)
 
     D = [float(D_A), float(D_B)]
 
@@ -55,15 +48,10 @@ def test_multispecies_dict_objects():
 
     A = F.Species("A")
     B = F.Species("B")
-    spe_list = [A, B]
 
     my_mat = F.Material(D_0={A: D_0_A, B: D_0_B}, E_D={A: E_D_A, B: E_D_B})
-    D_A = my_mat.get_diffusion_coefficient(
-        test_mesh.mesh, T, species=A, model_species=spe_list
-    )
-    D_B = my_mat.get_diffusion_coefficient(
-        test_mesh.mesh, T, species=B, model_species=spe_list
-    )
+    D_A = my_mat.get_diffusion_coefficient(test_mesh.mesh, T, species=A)
+    D_B = my_mat.get_diffusion_coefficient(test_mesh.mesh, T, species=B)
     D = [float(D_A), float(D_B)]
 
     D_A_analytical = D_0_A * np.exp(-E_D_A / F.k_B / T)
@@ -83,15 +71,10 @@ def test_multispecies_dict_objects_and_strings():
 
     A = F.Species("A")
     B = F.Species("B")
-    spe_list = [A, B]
 
     my_mat = F.Material(D_0={A: D_0_A, "B": D_0_B}, E_D={A: E_D_A, "B": E_D_B})
-    D_A = my_mat.get_diffusion_coefficient(
-        test_mesh.mesh, T, species=A, model_species=spe_list
-    )
-    D_B = my_mat.get_diffusion_coefficient(
-        test_mesh.mesh, T, species=B, model_species=spe_list
-    )
+    D_A = my_mat.get_diffusion_coefficient(test_mesh.mesh, T, species=A)
+    D_B = my_mat.get_diffusion_coefficient(test_mesh.mesh, T, species=B)
     D = [float(D_A), float(D_B)]
 
     D_A_analytical = D_0_A * np.exp(-E_D_A / F.k_B / T)
@@ -106,54 +89,10 @@ def test_multispecies_dict_different_keys():
     """Test that a value error is rasied when the keys of the D_0 and E_D
     are not the same"""
     A = F.Species("A")
-    spe_list = [A]
     my_mat = F.Material(D_0={"A": 1, "B": 2}, E_D={"A": 0.1, "B": 0.2, "C": 0.3})
 
     with pytest.raises(ValueError, match="D_0 and E_D have different keys"):
-        my_mat.get_diffusion_coefficient(
-            test_mesh.mesh, 500, species=A, model_species=spe_list
-        )
-
-
-def test_multispecies_dict_wrong_name_species_not_found():
-    """Test that a value error is rasied when the length of the D_0 and E_D
-    are not the same"""
-    J = F.Species("J")
-    spe_list = [J]
-    my_mat = F.Material(D_0={"A": 1, "B": 2}, E_D={"A": 0.1, "B": 0.2})
-
-    with pytest.raises(ValueError, match="Species A not found in list of species"):
-        my_mat.get_diffusion_coefficient(
-            test_mesh.mesh, 500, species=J, model_species=spe_list
-        )
-
-
-def test_multispecies_dict_contains_species_not_in_species_list():
-    """Test that a value error is rasied in the get_diffusion_coefficient
-    function"""
-    J = F.Species("J")
-    A = F.Species("A")
-    spe_list = [J]
-    my_mat = F.Material(D_0={A: 1, "B": 2}, E_D={A: 0.1, "B": 0.2})
-
-    with pytest.raises(ValueError, match="Species A not found in model species"):
-        my_mat.get_diffusion_coefficient(
-            test_mesh.mesh, 500, species=J, model_species=spe_list
-        )
-
-
-def test_contains_species_not_in_species_list():
-    """Test that a value error is rasied in the get_diffusion_coefficient
-    function with one species"""
-    J = F.Species("J")
-    A = F.Species("A")
-    spe_list = [J]
-    my_mat = F.Material(D_0=1, E_D=0)
-
-    with pytest.raises(ValueError, match="Species A not found in model species"):
-        my_mat.get_diffusion_coefficient(
-            test_mesh.mesh, 500, species=A, model_species=spe_list
-        )
+        my_mat.get_diffusion_coefficient(test_mesh.mesh, 500, species=A)
 
 
 def test_D_0_type_rasies_error():
@@ -164,6 +103,4 @@ def test_D_0_type_rasies_error():
     my_mat = F.Material(D_0=[1, 1], E_D=0.1)
 
     with pytest.raises(ValueError, match="D_0 and E_D must be either floats or dicts"):
-        my_mat.get_diffusion_coefficient(
-            test_mesh.mesh, 500, species=A, model_species=spe_list
-        )
+        my_mat.get_diffusion_coefficient(test_mesh.mesh, 500, species=A)

--- a/test/test_permeation_problem.py
+++ b/test/test_permeation_problem.py
@@ -60,7 +60,7 @@ def test_permeation_problem(mesh_size=1001):
     # -------------------------- analytical solution -------------------------------------
 
     D = my_mat.get_diffusion_coefficient(
-        my_mesh.mesh, my_model.temperature, my_model.species[0], my_model.species
+        my_mesh.mesh, my_model.temperature, my_model.species[0]
     )
 
     S_0 = float(my_model.boundary_conditions[-1].S_0)
@@ -155,9 +155,7 @@ def test_permeation_problem_multi_volume():
     times, flux_values = my_model.run()
 
     # ---------------------- analytical solution -----------------------------
-    D = my_mat.get_diffusion_coefficient(
-        my_mesh.mesh, temperature, my_model.species[0], model_species=my_model.species
-    )
+    D = my_mat.get_diffusion_coefficient(my_mesh.mesh, temperature, my_model.species[0])
 
     S_0 = float(my_model.boundary_conditions[-1].S_0)
     E_S = float(my_model.boundary_conditions[-1].E_S)


### PR DESCRIPTION
Users should be able to call get_diffusion_coefficient on a material without passing the model species.
Especially for a case where there is only one species.

This PR modifies Material.get_diffusion_coefficient by:
- removing the model_species argument
- making the species argument optional

No need for checking that the keys of `Material` are in the model since, in the model, you are already iterating through the species of the model.
